### PR TITLE
Use /dev/shm to store temporary data

### DIFF
--- a/pipeline.ml
+++ b/pipeline.ml
@@ -89,6 +89,8 @@ let pipeline ~github ~repo ?output_file ?slack_path ?docker_cpu
             "x86_64";
             "--addr-no-randomize";
             "_build/default/bench/db_bench.exe";
+            "-d";
+            "/dev/shm";
             "--bench";
             "index";
             "--json";


### PR DESCRIPTION
`db_bench` doesn't store temporary files in /dev/shm by default, specify with `-d`