### PR TITLE
Write to Postgres

### DIFF
--- a/dune
+++ b/dune
@@ -3,5 +3,5 @@
  (package pipeline)
  (libraries bos cmdliner current current.fs current_docker current_git
    current_github current_slack current_web dockerfile fmt.cli fmt.tty logs
-   logs.cli logs.fmt prometheus rresult uri curly))
+   logs.cli logs.fmt prometheus rresult uri curly postgresql))
 

--- a/utils.ml
+++ b/utils.ml
@@ -24,35 +24,6 @@ let get_commit repo owner user token =
   | Ok x -> get_commit_string x.Curly.Response.body
   | Error _ -> "failed"
 
-let num_file_dir path =
-  let dir_handle = Unix.opendir path in
-  let rec loop acc =
-    try
-      let _ = Unix.readdir dir_handle in
-      loop (acc + 1)
-    with End_of_file -> acc
-  in
-  let num = loop 0 in
-  let () = Unix.closedir dir_handle in
-  num
-
-let create_tmp_host repo commit_hash =
-  let path = "/data/tmp/" ^ repo in
-  let () =
-    if not (Sys.file_exists path) then try Unix.mkdir path 0o777 with _ -> ()
-  in
-  let path = path ^ "/" ^ commit_hash in
-  let () =
-    if not (Sys.file_exists path) then try Unix.mkdir path 0o777 with _ -> ()
-  in
-  let files = num_file_dir path in
-  let file_name = string_of_int files in
-  let path = path ^ "/" ^ file_name ^ ".json" in
-  let oc = open_out path in
-  let () = Unix.chmod path 0o666 in
-  let () = close_out oc in
-  Fpath.(v path)
-
 let merge_json repo commit json =
   Yojson.Basic.pretty_to_string
     (`Assoc
@@ -65,3 +36,17 @@ let read_file path =
       let len = in_channel_length ch in
       really_input_string ch len)
     ~finally:(fun () -> close_in ch)
+
+open! Postgresql
+
+let populate_postgres conninfo json_string =
+  try
+    let c = new connection ~conninfo () in
+    let _ =
+      c#exec ~expect:[ Command_ok ]
+        ("insert into index(benchmarks_data) values ( '" ^ json_string ^ "' )")
+    in
+    c#finish
+  with
+  | Error e -> prerr_endline (string_of_error e)
+  | e -> prerr_endline (Printexc.to_string e)


### PR DESCRIPTION
Write the json output of the benchmarks running inside
docker directly to postgres. The table currently is
just one column called "benchmarks_data" of type json.
Also, no longer need to mount files to docker to get the
output out.