### PR TITLE
Permission issue with postgres image

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ The metadata about `repo`, `branch` and `commit` is added by the pipeline. Your 
 
 Follow instructions from instructions here: https://hasura.io/docs/1.0/graphql/manual/deployment/docker/index.html
 
+### Troubleshooting
+
+You can `export FRONTEND_DIRECTORY=<location of frontend directory>` as a env variable if it is ignored by `docker-compose build`.
+
+If you run several times `docker-compose up` and failing to load the DB for some reasons, remember to remove the `db_data` folder before trying again, as [the `init.sql` is only run once](https://stackoverflow.com/questions/53249276/docker-compose-mysql-init-sql-is-not-executed).
+
 ## IO performance
 
 The results of IO bound benchmarks can vary greatly between different device/storage types and how they are configured. For this prototype we’re aiming for predictable results so we are using an in-memory `tmpfs` partition in `/dev/shm` for all storage.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,13 @@
 version: '3.6'
 services:
   postgres:
-    image: postgres:12
+    build: ./postgres
     environment:
     - POSTGRES_DB=docker
     - POSTGRES_USER=docker
     - POSTGRES_PASSWORD=docker
     restart: always
     volumes:
-    - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     - ./db_data:/var/lib/postgresql/data
     ports: ["5432:5432"]
   graphql-engine:

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12
+COPY ./init.sql /docker-entrypoint-initdb.d/init.sql
+CMD ["docker-entrypoint.sh", "postgres"]

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -2,7 +2,7 @@ GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
 
 CREATE TABLE benchmarks(
 	repositories varchar(256),
-	commits varchar(50),
+	commits varchar(50) NOT NULL UNIQUE,
 	json_data jsonb
 );
 


### PR DESCRIPTION
I had this error while running docker-compose: 

`psql: error: /docker-entrypoint-initdb.d/init.sql: Operation not permitted`

The issue and the solution is mentioned [here](https://stackoverflow.com/questions/60457838/docker-compose-postgres-docker-entrypoint-initdb-d-init-sql-permission-deni). I think that the copy of `init.sql` in `/docker-entrypoint-initdb.d/` requires root access. I tried setting the user to root in docker-compose directly, but that didn't work.

Let me know if this works for you. 