### PR TITLE
Update ocurrent

### DIFF
--- a/dune
+++ b/dune
@@ -4,4 +4,3 @@
  (libraries bos cmdliner current current.fs current_docker current_git
    current_github current_slack current_web dockerfile fmt.cli fmt.tty logs
    logs.cli logs.fmt prometheus rresult uri curly postgresql yojson))
-

--- a/logging.mli
+++ b/logging.mli
@@ -2,7 +2,8 @@ val init :
   ?style_renderer:Fmt.style_renderer -> ?level:Logs.level -> unit -> unit
 (** Initialise the Logs library with some sensible defaults. *)
 
-val with_dot : dotfile:Fpath.t -> (unit -> 'a Current.t) -> unit -> 'a Current.t
+val with_dot :
+  dotfile:string -> (unit -> unit Current.t) -> unit -> unit Current.t
 (** [with_dot ~dotfile pipeline] wraps [pipeline] to keep a dot diagram in
     [dotfile] showing its current state. *)
 

--- a/pipeline.ml
+++ b/pipeline.ml
@@ -17,8 +17,8 @@ let dockerfile ~base =
   let open Dockerfile in
   from (Docker.Image.hash base)
   @@ run
-       "sudo apt-get update && sudo apt-get install -qq -yy libffi-dev liblmdb-dev m4 pkg-config \
-        gnuplot-x11"
+       "sudo apt-get update && sudo apt-get install -qq -yy libffi-dev \
+        liblmdb-dev m4 pkg-config gnuplot-x11"
   @@ copy ~src:[ "--chown=opam:opam ." ] ~dst:"index" ()
   @@ workdir "index"
   @@ run "opam install -y --deps-only -t ."

--- a/pipeline.opam
+++ b/pipeline.opam
@@ -12,13 +12,15 @@ depends: [
   "bos"
   "capnp-rpc-unix"
   "cmdliner"
-  "current"
-  "current_docker"
-  "current_git"
-  "current_github"
-  "current_rpc"
-  "current_slack"
-  "current_web"
+  "current" {>= "0.2"}
+  "current_ansi" {>= "0.2"}
+  "current_docker" {>= "0.2"}
+  "current_git" {>= "0.2"}
+  "current_github" {>= "0.2"}
+  "current_incr" {>= "0.2"}
+  "current_rpc" {>= "0.2"}
+  "current_slack" {>= "0.2"}
+  "current_web" {>= "0.2"}
   "curly"
   "duration"
   "fpath"
@@ -43,13 +45,3 @@ build: [
 ]
 dev-repo: "git+https://github.com/gs0510/index-benchmarks.git"
 
-pin-depends: [
-  [ "current.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_ansi.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_docker.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_git.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_github.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_rpc.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_slack.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-  [ "current_web.dev" "git+https://github.com/ocurrent/ocurrent#77ced6c4f2a0126fcc654e96bb4bc79af764d634" ]
-]

--- a/utils.ml
+++ b/utils.ml
@@ -74,7 +74,7 @@ let get_data_from_json commit json =
           (metrics |> member "ops_per_sec" |> to_float |> string_of_float))
       bench_objects bench_names
   in
-  (String.concat "," result_string) ^ "," ^ ( string_of_float (Unix.time()))
+  String.concat "," result_string ^ "," ^ string_of_float (Unix.time ())
 
 open! Postgresql
 


### PR DESCRIPTION
Previous pin to `ocurrent` was to a commit not found (maybe force pushed ?). I updated the code, it should compile now with the latest release `0.2`.

I hope I didn't break anything, it would be nice to add some tests at some point. 